### PR TITLE
Run sync server in a fiber

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "nyholm/psr7": "^1.4",
         "nyholm/psr7-server": "^1.0",
         "psr/http-server-middleware": "^1.0",
+        "react/async": "@dev",
         "react/http": "^1.5",
         "symfony/runtime": "^5.3"
     },

--- a/src/SyncRunner.php
+++ b/src/SyncRunner.php
@@ -9,6 +9,7 @@ use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7Server\ServerRequestCreator;
 use React\EventLoop\Loop;
+use function React\Async\async;
 
 final class SyncRunner
 {
@@ -31,11 +32,13 @@ final class SyncRunner
 
     public function run(): int
     {
-        $this->sapi->emit(
-            $this->application->handle($this->responseFactory->fromGlobals())
-        );
-
         $loop = Loop::get();
+        async(function (): void {
+            $this->sapi->emit(
+                $this->application->handle($this->responseFactory->fromGlobals())
+            );
+        });
+
         $loop->run();
 
         return 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Running await makes the current sync server fail with a segmentation fault because the fiber isn't already started.

## Motivation and context

It fixes the described situation and adds real support to use async APIs inside the sync server.

## How has this been tested?

Covered by unit tests and tested manually

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/1093654/146449290-a29e9a0c-a0d7-47e8-900a-01d5ef52cb6d.png)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

